### PR TITLE
🥢Some nit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo is in violation of the terms of the BSL. The BSL is dumb and we should
 Changes made
 - deleted protocol fee stuff because it's stupid overhead that never gets turned on
 - updated the readme
-- disabled tests b/c i didn't feel like updating them)
+- disabled tests b/c i didn't feel like updating them
 - documented deployment command
 
 ### Deploying:
@@ -13,7 +13,7 @@ Changes made
 This code has been deployed to [Goerli](https://goerli.etherscan.io/address/0x730e2011643511eb37a9eb315ac520df694aac3b)
 
 ```
-forge c PoolManager --rpc-url $MY_RPC --private-key $MY_PRIVATE_KEY --constructor-args $CONTROLLER_GAS_LIMIT --verify
+forge c PoolManager --rpc-url $MY_RPC --private-key $MY_PRIVATE_KEY --constructor-args $CONTROLLER_GAS_LIMIT --etherscan-api-key $ETHERSCAN_API_KEY --verify
 ```
 
 

--- a/contracts/PoolManager.sol
+++ b/contracts/PoolManager.sol
@@ -63,7 +63,7 @@ contract PoolManager is IPoolManager, NoDelegateCall, ERC1155, IERC1155Receiver 
 
     mapping(address hookAddress => mapping(Currency currency => uint256)) public hookFeesAccrued;
 
-    constructor(uint256 _controllerGasLimit) ERC1155("") {
+    constructor(uint256 _controllerGasLimit) payable ERC1155("") {
         controllerGasLimit = _controllerGasLimit;
     }
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,9 @@ solc_version = '0.8.20'
 ffi = true
 fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}, { access = "read", path = "./foundry-out"}]
 via_ir = true
+evm_version = 'paris'
+
+[profile.shanghai]
 evm_version = 'shanghai'
 
 [profile.ci]

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ solc_version = '0.8.20'
 ffi = true
 fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}, { access = "read", path = "./foundry-out"}]
 via_ir = true
+evm_version = 'shanghai'
 
 [profile.ci]
 fuzz_runs = 100000


### PR DESCRIPTION
Unfortunately, the full action happened when I went to bed yesterday lol (it was 3 am for me when that discussion started on Twitter lol)

Still, some suggested changes:

- Constructor `payable` cuts out 10 opcodes from the init code
- Fixed `README` deployment script with missing Etherscan API key
- Let's show some love for `PUSH0` (as long as we deploy on a chain that supports it ;-)) 